### PR TITLE
fix: Use ConfigType instead of Config for hass.config

### DIFF
--- a/custom_components/foldingathomecontrol/__init__.py
+++ b/custom_components/foldingathomecontrol/__init__.py
@@ -3,7 +3,8 @@
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import (
@@ -36,7 +37,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Configure PyFoldingAtHomeControl using config flow only."""
     if DOMAIN in config:
         _LOGGER.warning(


### PR DESCRIPTION
Per https://developers.home-assistant.io/blog/2024/10/31/core-config-moved, the config class has been updated and a deprecation warning now appears in the HA logs.

```shell
Logger: homeassistant.core
Source: helpers/deprecation.py:222
First occurred: 9:51:24 PM (1 occurrences)
Last logged: 9:51:24 PM

Config was used from foldingathomecontrol, this is a deprecated alias which will be removed in HA Core 2025.11. Use homeassistant.core_config.Config instead, please report it to the author of the 'foldingathomecontrol' custom integration
```

This PR makes the necessary changes