### PR TITLE
fix: Update OptionsFlow property in config_flow.py

### DIFF
--- a/custom_components/foldingathomecontrol/config_flow.py
+++ b/custom_components/foldingathomecontrol/config_flow.py
@@ -80,8 +80,9 @@ class FoldingAtHomeControllerFlowHandler(config_entries.ConfigFlow):
 class FoldingAtHomeControlOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle FoldingAtHomeControl client options."""
 
-    def __init__(self) -> None:
+    def __init__(self, config_entry) -> None:
         """Initialize FoldingAtHomeControl options flow."""
+        #self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None) -> config_entries.ConfigFlowResult:
         """Manage the FoldingAtHomeControl options."""

--- a/custom_components/foldingathomecontrol/config_flow.py
+++ b/custom_components/foldingathomecontrol/config_flow.py
@@ -80,9 +80,8 @@ class FoldingAtHomeControllerFlowHandler(config_entries.ConfigFlow):
 class FoldingAtHomeControlOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle FoldingAtHomeControl client options."""
 
-    def __init__(self, config_entry) -> None:
+    def __init__(self) -> None:
         """Initialize FoldingAtHomeControl options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None) -> config_entries.ConfigFlowResult:
         """Manage the FoldingAtHomeControl options."""


### PR DESCRIPTION
When adding a new folding instance, my HA logs now show the following warning:
```
2024-12-21 06:10:28.977 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'foldingathomecontrol' sets option flow config_entry explicitly, which is deprecated at custom_components/foldingathomecontrol/config_flow.py, line 85: self.config_entry = config_entry. This will stop working in Home Assistant 2025.12, please create a bug report at https://github.com/eifinger/hass-foldingathomecontrol/issues
```

Looks like this was deprecated in November 2024 [per the dev blog](https://developers.home-assistant.io/blog/2024/11/12/options-flow#backwards-compatibility)